### PR TITLE
builtin.lua: Add LspInlayHint

### DIFF
--- a/lua/midnight/highlight/builtin.lua
+++ b/lua/midnight/highlight/builtin.lua
@@ -23,6 +23,7 @@ return {
   IncSearch = { fg = c.bg, bg = p.orange[1] },
   Substitute = { fg = c.bg, bg = p.red[1] },
   LineNr = { fg = p.gray[5] },
+  LspInlayHint = { fg = c.hint },
   CursorLineNr = { fg = p.gray[1] },
   MatchParen = { bg = p.cyan[4] },
   ModeMsg = { link = 'Normal' },


### PR DESCRIPTION
The support for LspInlayHint was added i Neovim v0.10.0 and some language plugins only support this feature for inlay hints like rustaceanvim. This results in inlay hints with a black foreground color on a black background color which is quite hard to interpret ;).

This patch will add support for LspInlayHint and set the color to the midnight's hint color.